### PR TITLE
Add Jest setup and sample server test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # copilot-mcp
+
+## Running Tests
+
+Install dependencies and run the test suite with:
+
+```bash
+npm install
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "copilot-mcp",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,7 @@
+export async function startServer(): Promise<void> {
+  console.log('Server started');
+}
+
+if (require.main === module) {
+  startServer();
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,7 @@
+import { startServer } from '../src/server';
+
+describe('MCP server', () => {
+  it('starts without throwing', async () => {
+    await expect(startServer()).resolves.toBeUndefined();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- initialize Node project with Jest testing config
- create minimal server and add a basic startup test
- document how to run the tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687131acec3c83329b1696517dd1cb4f