### PR TITLE
Add docs for MCP tools and setup

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,87 @@
+# MCP Tools API
+
+This document describes the tools exposed by the GitHub Copilot MCP server. Each tool is defined using JSON Schema for its input and output.
+
+## copilot_complete
+
+Generates code completions from GitHub Copilot based on the provided prompt.
+
+### Input Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "prompt": { "type": "string", "description": "Code snippet or question" },
+    "language": { "type": "string", "description": "Programming language", "default": "" }
+  },
+  "required": ["prompt"]
+}
+```
+
+### Output Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "completion": { "type": "string", "description": "Generated completion" }
+  },
+  "required": ["completion"]
+}
+```
+
+## copilot_review
+
+Provides automated code review comments for a given file or snippet.
+
+### Input Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "code": { "type": "string", "description": "Source code to review" },
+    "language": { "type": "string", "description": "Programming language" }
+  },
+  "required": ["code"]
+}
+```
+
+### Output Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "comments": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of review comments"
+    }
+  },
+  "required": ["comments"]
+}
+```
+
+## copilot_explain
+
+Explains what a piece of code does in plain language.
+
+### Input Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "code": { "type": "string", "description": "Code to explain" }
+  },
+  "required": ["code"]
+}
+```
+
+### Output Schema
+```json
+{
+  "type": "object",
+  "properties": {
+    "explanation": { "type": "string", "description": "Plain language explanation" }
+  },
+  "required": ["explanation"]
+}
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,43 @@
+# Local Development Setup
+
+This project is a Model Context Protocol (MCP) server that bridges Warp Terminal and GitHub Copilot. Follow these steps to get a local environment running.
+
+## Prerequisites
+
+- Node.js or Python 3.8+
+- Git
+- GitHub App credentials for accessing the Copilot API
+
+## Installation
+
+```bash
+# Clone the repository
+git clone <your-fork-url>
+cd mcp-github-copilot-server
+
+# Install dependencies
+npm install    # or: pip install -r requirements.txt
+
+# Copy the example GitHub App config
+cp config/github-app.example.json config/github-app.json
+# Edit config/github-app.json with your App ID, private key, and installation ID
+```
+
+## Running the Server
+
+```bash
+# Start the development server
+npm run dev    # or: python src/server.py
+```
+
+The server communicates over stdio by default. When it starts, it registers available tools with Warp.
+
+## Warp Terminal Configuration
+
+In Warp, add this MCP server via **Settings → AI → Manage MCP Servers** and point it to the start command above. Ensure the environment variables for your GitHub App are available when launching the server.
+
+## Troubleshooting
+
+- Check that your GitHub App credentials are valid and have the required permissions.
+- Verify network connectivity if requests to GitHub Copilot fail.
+- Inspect logs for detailed error messages.


### PR DESCRIPTION
## Summary
- document GitHub Copilot MCP tools
- document local development setup

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687131ab9bc48332adbe1c0449b9dd37