### PR TITLE
Add Jest and server tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "copilot-mcp",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@octokit/rest": "^20.0.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "@types/jest": "^29.5.3",
+    "@types/node": "^18.18.0",
+    "jest": "^29.6.1",
+    "nock": "^13.3.3",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import { Octokit } from '@octokit/rest';
+
+const app = express();
+app.use(express.json());
+
+app.post('/rpc', async (req, res) => {
+  const { id, jsonrpc, method, params } = req.body;
+  if (jsonrpc !== '2.0') {
+    return res.status(400).json({ jsonrpc: '2.0', id, error: { code: -32600, message: 'Invalid JSON-RPC version' } });
+  }
+
+  if (method === 'echo') {
+    return res.json({ jsonrpc: '2.0', id, result: params });
+  }
+
+  if (method === 'getRepo') {
+    const [owner, repo] = params as [string, string];
+    try {
+      const octokit = new Octokit();
+      const { data } = await octokit.repos.get({ owner, repo });
+      return res.json({ jsonrpc: '2.0', id, result: data });
+    } catch (err) {
+      return res.json({ jsonrpc: '2.0', id, error: { code: -32000, message: 'GitHub API error' } });
+    }
+  }
+
+  return res.json({ jsonrpc: '2.0', id, error: { code: -32601, message: 'Method not found' } });
+});
+
+export default app;
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,32 @@
+import request from 'supertest';
+import nock from 'nock';
+import app from '../src/server';
+
+describe('MCP server', () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it('responds to echo JSON-RPC request', async () => {
+    const res = await request(app)
+      .post('/rpc')
+      .send({ jsonrpc: '2.0', id: 1, method: 'echo', params: { msg: 'hi' } });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ jsonrpc: '2.0', id: 1, result: { msg: 'hi' } });
+  });
+
+  it('fetches repo info via GitHub API', async () => {
+    const scope = nock('https://api.github.com')
+      .get('/repos/octocat/Hello-World')
+      .reply(200, { full_name: 'octocat/Hello-World' });
+
+    const res = await request(app)
+      .post('/rpc')
+      .send({ jsonrpc: '2.0', id: 2, method: 'getRepo', params: ['octocat', 'Hello-World'] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ jsonrpc: '2.0', id: 2, result: { full_name: 'octocat/Hello-World' } });
+    scope.done();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- add Jest and TypeScript setup
- implement a minimal Express server with JSON-RPC support
- mock GitHub API calls using `nock`
- add server tests verifying echo and repo methods

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687131d01e0083329a4ff19869ec8f9a