### PR TITLE
Add pytest with simple server sanity test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -v

--- a/src/server.py
+++ b/src/server.py
@@ -1,0 +1,23 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/ping':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'message': 'pong'}).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def run(port: int = 8000):
+    server = HTTPServer(('localhost', port), Handler)
+    print('Server running on port', port, flush=True)
+    server.serve_forever()
+
+
+if __name__ == '__main__':
+    run()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+import time
+import urllib.request
+import json
+from pathlib import Path
+
+SERVER_SCRIPT = str(Path(__file__).resolve().parent.parent / 'src' / 'server.py')
+
+
+def start_server():
+    proc = subprocess.Popen([sys.executable, SERVER_SCRIPT], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # wait briefly for server to start
+    time.sleep(0.5)
+    return proc
+
+
+def stop_server(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def test_server_responds_to_ping():
+    proc = start_server()
+    try:
+        with urllib.request.urlopen('http://localhost:8000/ping') as resp:
+            data = json.load(resp)
+        assert data.get('message') == 'pong'
+    finally:
+        stop_server(proc)


### PR DESCRIPTION
## Summary
- set up Python test runner with pytest
- add a minimal HTTP server for ping checks
- sanity test ensures the server starts and replies to `/ping`
- ignore Python cache directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687131a12f208332b9d1e1c239a5cd5a