### PR TITLE
Add Jest test runner and server startup test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Contributions are welcome! Please follow the guidelines in `AGENTS.md` regarding
 
 ## Testing
 
-Run the automated test suite with:
+Unit tests are written with **Jest**. Run the suite with:
 ```bash
 npm test
 ```

--- a/package.json
+++ b/package.json
@@ -5,12 +5,22 @@
   "main": "dist/server.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/server.js"
+    "start": "node dist/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^latest"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "@types/jest": "^29.5.2",
+    "ts-node": "^10.9.1"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testMatch": ["**/tests/**/*.test.ts"]
   }
 }

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,24 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { once } from 'events';
+
+describe('mcp server startup', () => {
+  it('responds to initialize request', async () => {
+    const tsNode = path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node');
+    const serverPath = path.resolve(__dirname, '..', 'src', 'server.ts');
+    const child = spawn(tsNode, [serverPath], { stdio: ['pipe', 'pipe', 'inherit'] });
+
+    const request = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: { version: 'test' }
+    }) + '\n';
+
+    child.stdin.write(request);
+    const [data] = await once(child.stdout, 'data');
+    const response = JSON.parse(String(data).trim());
+    expect(response.result).toBeDefined();
+    child.kill();
+  }, 10000);
+});


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest in `package.json`
- add basic startup test for the MCP server
- document running tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713494593083328b8e2fdd2538f0a4