### PR TITLE
Update README with setup steps and Warp integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,38 @@
-# MCP GitHub Copilot Server
+# GitHub Copilot MCP Server
 
-This project implements a Model Context Protocol (MCP) server that enables Warp Terminal agents to query GitHub Copilot. It acts as a bridge between Warp's Agent Mode and GitHub Copilot's API, providing code completion and analysis features directly in the terminal.
-
-## Technology Stack
-
-- **Runtime:** Node.js with TypeScript
-- **Protocol:** JSON-RPC 2.0 over stdio for Warp integration
-- **Dependencies:** `@modelcontextprotocol/sdk`, `@octokit/rest`, `zod`, `jsonwebtoken`
+This repository contains a lightweight Model Context Protocol (MCP) server that lets Warp Terminal's Agent Mode talk to GitHub Copilot. It exposes Copilot tools over JSON-RPC 2.0 using stdio so Warp can request completions and code analysis directly from the terminal.
 
 ## Setup
 
-1. Clone the repository and install dependencies:
+1. **Install dependencies**
+
    ```bash
-   git clone <this-repo>
-   cd copilot-mcp
    npm install
    ```
-2. Configure your GitHub App credentials:
+   See `AGENTS.md` for the complete dependency list and optional installation notes.
+
+2. **Configure GitHub App credentials**
+
    ```bash
    cp config/github-app.example.json config/github-app.json
-   # Edit config/github-app.json with your GITHUB_APP_ID, private key path and installation ID
+   # Edit config/github-app.json with your appId, private key and installationId
    ```
-   See the **Authentication** and **Configuration** specs in `AGENTS.md` for details on generating a JWT and creating installation tokens.
-3. Start the development server:
-   ```bash
-   npm run dev
-   ```
+   Guidance on generating tokens and keeping them secure is in the *GitHub App Security* section of `AGENTS.md`.
 
-## Using with Warp
+## Development server
 
-Add the server to Warp's MCP configuration. A minimal entry looks like:
+Start the server in development mode with:
+
+```bash
+npm run dev
+```
+
+The server listens on stdio for MCP requests.
+
+## Warp Terminal integration
+
+Add the server in Warp's *Manage MCP servers* configuration:
+
 ```json
 {
   "name": "github-copilot",
@@ -43,17 +46,9 @@ Add the server to Warp's MCP configuration. A minimal entry looks like:
   "start_on_launch": true
 }
 ```
-Launch Warp and the server will provide Copilot completions for supported commands.
+
+Once registered, Warp will route completion and review requests through this server to GitHub Copilot.
 
 ## Contributing
 
-Contributions are welcome! Please follow the guidelines in `AGENTS.md` regarding MCP protocol compliance, error handling and performance. New features should include accompanying tests and documentation.
-
-## Testing
-
-Run the automated test suite with:
-```bash
-npm test
-```
-End-to-end tests with Warp can be executed using `warp_agent_test` as described in the **Testing Strategy** section of `AGENTS.md`. Ensure authentication and configuration are valid before running tests.
-
+Please follow the development guidelines in `AGENTS.md` when proposing changes.


### PR DESCRIPTION
## Summary
- replace README with new introduction
- document dependency installation and GitHub App credentials setup referencing `AGENTS.md`
- show how to start the dev server
- include Warp Terminal configuration snippet

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6871348df80483329c376b7d889b4e7f