### PR TITLE
Fix installation token return

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -55,7 +55,7 @@ async function createInstallationToken(config: GitHubAppConfig): Promise<{ token
   const res = await appOctokit.rest.apps.createInstallationAccessToken({
     installation_id: Number(config.installationId),
   });
-  return { token: res.data.token, expires_at: res.data.expires_at } as any;
+  return { token: res.data.token, expiresAt: res.data.expires_at };
 }
 
 async function createInstallationTokenWithRetry(config: GitHubAppConfig, retries = 2): Promise<{ token: string; expiresAt: string }> {


### PR DESCRIPTION
## Summary
- return the correct keys from `createInstallationToken`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713e3c316883328eb355ca41c08994