### PR TITLE
Handle GitHub App credentials securely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ logs/
 config/*.local.json
 config/*.dev.json
 config/*.generated.json
+config/github-app.json
 
 # Logs
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ This project implements a Model Context Protocol (MCP) server that enables Warp 
    cd copilot-mcp
    npm install
    ```
-2. Configure your GitHub App credentials:
+2. Configure your GitHub App credentials using environment variables:
    ```bash
-   cp config/github-app.example.json config/github-app.json
-   # Edit config/github-app.json with your GITHUB_APP_ID, private key path and installation ID
+   export GITHUB_APP_ID=<your_app_id>
+   export GITHUB_INSTALLATION_ID=<your_installation_id>
+   export GITHUB_PRIVATE_KEY_PATH=/path/to/private-key.pem
+   # or set GITHUB_PRIVATE_KEY with the PEM contents
    ```
-   See the **Authentication** and **Configuration** specs in `AGENTS.md` for details on generating a JWT and creating installation tokens.
+   You may still provide `config/github-app.json` for `appId` and `installationId`, but **never** commit your private key. See the **Authentication** and **Configuration** specs in `AGENTS.md` for details on generating a JWT and creating installation tokens.
 3. Start the development server:
    ```bash
    npm run dev

--- a/config/github-app.json
+++ b/config/github-app.json
@@ -1,5 +1,0 @@
-{
-  "appId": "",
-  "privateKey": "",
-  "installationId": ""
-}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -18,9 +18,13 @@ cd mcp-github-copilot-server
 # Install dependencies
 npm install    # or: pip install -r requirements.txt
 
-# Copy the example GitHub App config
-cp config/github-app.example.json config/github-app.json
-# Edit config/github-app.json with your App ID, private key, and installation ID
+# Configure your GitHub App credentials via environment variables
+export GITHUB_APP_ID=<your_app_id>
+export GITHUB_INSTALLATION_ID=<your_installation_id>
+export GITHUB_PRIVATE_KEY_PATH=/path/to/private-key.pem
+# or set GITHUB_PRIVATE_KEY with the PEM contents
+# Never commit your private key to version control. Use environment variables or
+# a secure secrets manager to store it locally.
 ```
 
 ## Running the Server

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,19 +14,23 @@ let tokenExpiresAt = 0;
 
 async function readConfig(): Promise<GitHubAppConfig> {
   const envAppId = process.env.GITHUB_APP_ID;
-  let envPrivateKey = process.env.GITHUB_PRIVATE_KEY;
-  const envPrivateKeyPath = process.env.GITHUB_PRIVATE_KEY_PATH;
   const envInstallationId = process.env.GITHUB_INSTALLATION_ID;
+  let privateKey = process.env.GITHUB_PRIVATE_KEY;
+  const privateKeyPath = process.env.GITHUB_PRIVATE_KEY_PATH;
 
-  if (!envPrivateKey && envPrivateKeyPath) {
-    envPrivateKey = await fs.readFile(envPrivateKeyPath, 'utf8');
+  if (!privateKey && privateKeyPath) {
+    privateKey = await fs.readFile(privateKeyPath, 'utf8');
   }
 
-  if (envAppId && envPrivateKey) {
+  if (!privateKey) {
+    throw new Error('GitHub private key must be provided via GITHUB_PRIVATE_KEY or GITHUB_PRIVATE_KEY_PATH');
+  }
+
+  if (envAppId && envInstallationId) {
     return {
       appId: envAppId,
-      privateKey: envPrivateKey,
       installationId: envInstallationId,
+      privateKey,
     };
   }
 
@@ -34,9 +38,9 @@ async function readConfig(): Promise<GitHubAppConfig> {
   const raw = await fs.readFile(filePath, 'utf8');
   const data = JSON.parse(raw);
   return {
-    appId: data.appId,
-    privateKey: data.privateKey,
-    installationId: data.installationId,
+    appId: envAppId ?? data.appId,
+    installationId: envInstallationId ?? data.installationId,
+    privateKey,
   };
 }
 


### PR DESCRIPTION
## Summary
- stop tracking default credentials file and add it to gitignore
- read GitHub App private key only from environment variables or a path
- document secure env variable configuration in README and setup docs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723dd9169c833287469ea928369d0e