### PR TITLE
Add unit and integration tests

### DIFF
--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,48 @@
+import { getInstallationToken, refreshGitHubAuth } from '../src/auth';
+import { Octokit } from '@octokit/rest';
+import fs from 'fs';
+
+jest.mock('fs');
+jest.mock('@octokit/rest');
+
+describe('auth', () => {
+  const mockedFs = fs as unknown as jest.Mocked<typeof fs>;
+  const mockOctokit = {
+    rest: {
+      apps: {
+        createInstallationAccessToken: jest.fn()
+      }
+    }
+  } as any;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (Octokit as unknown as jest.Mock).mockImplementation(() => mockOctokit);
+    mockedFs.promises = {
+      readFile: jest.fn().mockResolvedValue('mock-key') as any
+    } as any;
+    process.env.GITHUB_APP_ID = '1';
+    process.env.GITHUB_PRIVATE_KEY = 'key';
+    process.env.GITHUB_INSTALLATION_ID = '2';
+  });
+
+  it('refreshes and caches token', async () => {
+    const tokenData = {
+      data: { token: 'abc', expires_at: new Date(Date.now() + 60000).toISOString() }
+    };
+    mockOctokit.rest.apps.createInstallationAccessToken.mockResolvedValue(tokenData);
+
+    const token = await getInstallationToken();
+    expect(token).toBe('abc');
+    expect(mockOctokit.rest.apps.createInstallationAccessToken).toHaveBeenCalledTimes(1);
+
+    const token2 = await getInstallationToken();
+    expect(token2).toBe('abc');
+    expect(mockOctokit.rest.apps.createInstallationAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when installation id missing', async () => {
+    delete process.env.GITHUB_INSTALLATION_ID;
+    await expect(refreshGitHubAuth()).rejects.toThrow('Missing installation id');
+  });
+});

--- a/tests/schemas.test.ts
+++ b/tests/schemas.test.ts
@@ -1,0 +1,17 @@
+import { copilotCompleteSchema, copilotReviewSchema, copilotExplainSchema } from '../src/schemas';
+
+describe('schemas', () => {
+  it('validates copilot_complete', () => {
+    const input = { code: 'function test(){}', language: 'typescript' };
+    expect(() => copilotCompleteSchema.parse(input)).not.toThrow();
+  });
+
+  it('fails missing code in copilot_review', () => {
+    expect(() => copilotReviewSchema.parse({} as any)).toThrow();
+  });
+
+  it('applies defaults for copilot_explain', () => {
+    const parsed = copilotExplainSchema.parse({ code: 'x' });
+    expect(parsed.include_examples).toBe(false);
+  });
+});

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2,23 +2,38 @@ import { spawn } from 'child_process';
 import path from 'path';
 import { once } from 'events';
 
-describe('mcp server startup', () => {
-  it('responds to initialize request', async () => {
-    const tsNode = path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node');
-    const serverPath = path.resolve(__dirname, '..', 'src', 'server.ts');
+describe('mcp server', () => {
+  const tsNode = path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node');
+  const serverPath = path.resolve(__dirname, '..', 'src', 'server.ts');
+
+  function sendRequest(child: any, id: number, method: string, params: any = {}) {
+    const req = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
+    child.stdin.write(req);
+  }
+
+  it('handles initialize and tool stubs', async () => {
     const child = spawn(tsNode, [serverPath], { stdio: ['pipe', 'pipe', 'inherit'] });
 
-    const request = JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: { version: 'test' }
-    }) + '\n';
+    sendRequest(child, 1, 'initialize', { version: 'test' });
+    let [data] = await once(child.stdout, 'data');
+    let response = JSON.parse(String(data).trim());
+    expect(response.result.capabilities).toBeDefined();
 
-    child.stdin.write(request);
-    const [data] = await once(child.stdout, 'data');
-    const response = JSON.parse(String(data).trim());
-    expect(response.result).toBeDefined();
+    sendRequest(child, 2, 'copilot_complete', {});
+    ;[data] = await once(child.stdout, 'data');
+    response = JSON.parse(String(data).trim());
+    expect(response.error.message).toMatch('not implemented');
+
+    sendRequest(child, 3, 'copilot_review', {});
+    ;[data] = await once(child.stdout, 'data');
+    response = JSON.parse(String(data).trim());
+    expect(response.error.message).toMatch('not implemented');
+
+    sendRequest(child, 4, 'copilot_explain', {});
+    ;[data] = await once(child.stdout, 'data');
+    response = JSON.parse(String(data).trim());
+    expect(response.error.message).toMatch('not implemented');
+
     child.kill();
-  }, 10000);
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- extend server integration test to cover tool handlers
- add auth unit tests mocking Octokit
- add schema validation tests

## Testing
- `npm test -- --coverage` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723ddae2c4833283f3834d33d77c53