### PR TITLE
Improve Warp setup and production deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,61 @@ This project implements a Model Context Protocol (MCP) server that enables Warp 
 
 ## Using with Warp
 
-Add the server to Warp's MCP configuration. A minimal entry looks like:
-```json
-{
-  "name": "github-copilot",
-  "command": "node",
-  "args": ["dist/server.js"],
-  "env": {
-    "GITHUB_APP_ID": "your_app_id",
-    "GITHUB_PRIVATE_KEY_PATH": "/path/to/private-key.pem",
-    "GITHUB_INSTALLATION_ID": "your_installation_id"
-  },
-  "start_on_launch": true
-}
+1. Build the server so Warp can launch the compiled code:
+   ```bash
+   npm run build
+   ```
+2. In Warp open **Settings → AI → Manage MCP Servers** and click **Add Server**.
+3. Fill in the configuration as shown below and save it:
+   ```json
+   {
+     "name": "github-copilot",
+     "command": "node",
+     "args": ["dist/server.js"],
+     "env": {
+       "GITHUB_APP_ID": "your_app_id",
+       "GITHUB_PRIVATE_KEY_PATH": "/path/to/private-key.pem",
+       "GITHUB_INSTALLATION_ID": "your_installation_id"
+     },
+     "start_on_launch": true
+   }
+   ```
+Warp will launch the server and Copilot completions will be available for supported commands.
+
+## Production Deployment
+
+For long-running use you can manage the compiled server with **systemd** or **Docker**.
+
+### systemd
+
+Create `/etc/systemd/system/github-copilot.service` and enable it:
+
+```ini
+[Service]
+ExecStart=/usr/bin/node /opt/copilot-mcp/dist/server.js
+WorkingDirectory=/opt/copilot-mcp
+Environment=GITHUB_APP_ID=your_app_id
+Environment=GITHUB_PRIVATE_KEY_PATH=/opt/copilot-mcp/private-key.pem
+Environment=GITHUB_INSTALLATION_ID=your_installation_id
+Restart=on-failure
 ```
-Launch Warp and the server will provide Copilot completions for supported commands.
+
+```bash
+sudo systemctl enable --now github-copilot.service
+```
+
+### Docker
+
+```bash
+docker build -t copilot-mcp .
+docker run -d --restart unless-stopped \
+  -e GITHUB_APP_ID=your_app_id \
+  -e GITHUB_PRIVATE_KEY_PATH=/keys/private.pem \
+  -e GITHUB_INSTALLATION_ID=your_installation_id \
+  copilot-mcp
+```
+
+Monitor the process using `journalctl` or `docker logs`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- expand instructions for adding the server to Warp in `README.md` and `docs/SETUP.md`
- document how to run the server in production via `systemd` or Docker

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723ddc8b2c83328bacbb13b4983bc3