### PR TITLE
Implement pino logging and add health check

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@octokit/rest": "latest",
     "jsonwebtoken": "latest",
     "zod": "latest",
-    "zod-to-json-schema": "latest"
+    "zod-to-json-schema": "latest",
+    "pino": "latest"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,8 @@
+import pino from 'pino';
+
+const level = process.env.LOG_LEVEL || 'info';
+
+// Use stderr for logs to avoid interfering with JSON-RPC stdout transport
+const logger = pino({ level }, pino.destination({ fd: 2 }));
+
+export default logger;

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,8 @@ import {
   ErrorCodes
 } from '@modelcontextprotocol/sdk';
 
+import logger from './logger';
+
 interface CapabilityMap {
   copilot_complete: boolean;
   copilot_review: boolean;
@@ -22,6 +24,7 @@ interface InitializeParams {
 // Set up stdio transport and JSON-RPC server
 const transport = createStdioTransport(process.stdin, process.stdout);
 const server = new JSONRPCServer(transport);
+logger.info('Starting MCP server');
 
 /** Structured error helper */
 function toJSONRPCError(message: string, code: number = ErrorCodes.InternalError): JSONRPCErrorResponse {
@@ -30,6 +33,7 @@ function toJSONRPCError(message: string, code: number = ErrorCodes.InternalError
 
 /** Initialization handshake */
 server.addMethod('initialize', async (params: JSONRPCParams<InitializeParams>) => {
+  logger.info({ params }, 'initialize');
   const capabilities: CapabilityMap = {
     copilot_complete: true,
     copilot_review: true,
@@ -40,21 +44,31 @@ server.addMethod('initialize', async (params: JSONRPCParams<InitializeParams>) =
 
 /** Stub handler: copilot_complete */
 server.addMethod('copilot_complete', async () => {
+  logger.warn('copilot_complete called but not implemented');
   return toJSONRPCError('copilot_complete not implemented', ErrorCodes.MethodNotFound);
 });
 
 /** Stub handler: copilot_review */
 server.addMethod('copilot_review', async () => {
+  logger.warn('copilot_review called but not implemented');
   return toJSONRPCError('copilot_review not implemented', ErrorCodes.MethodNotFound);
 });
 
 /** Stub handler: copilot_explain */
 server.addMethod('copilot_explain', async () => {
+  logger.warn('copilot_explain called but not implemented');
   return toJSONRPCError('copilot_explain not implemented', ErrorCodes.MethodNotFound);
+});
+
+/** Health check */
+server.addMethod('health_check', async () => {
+  logger.debug('health_check');
+  return { status: 'ok' };
 });
 
 // Start processing requests from stdio
 server.start().catch((err: unknown) => {
+  logger.error({ err }, 'server start failure');
   const errorResponse = toJSONRPCError((err as Error).message);
   transport.write(errorResponse);
 });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -21,4 +21,23 @@ describe('mcp server startup', () => {
     expect(response.result).toBeDefined();
     child.kill();
   }, 10000);
+
+  it('responds to health_check request', async () => {
+    const tsNode = path.resolve(__dirname, '..', 'node_modules', '.bin', 'ts-node');
+    const serverPath = path.resolve(__dirname, '..', 'src', 'server.ts');
+    const child = spawn(tsNode, [serverPath], { stdio: ['pipe', 'pipe', 'inherit'] });
+
+    const request = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'health_check',
+      params: {}
+    }) + '\n';
+
+    child.stdin.write(request);
+    const [data] = await once(child.stdout, 'data');
+    const response = JSON.parse(String(data).trim());
+    expect(response.result).toEqual({ status: 'ok' });
+    child.kill();
+  }, 10000);
 });


### PR DESCRIPTION
## Summary
- include pino for structured logging
- log server events via new logger
- expose a `health_check` JSON-RPC method
- test that health_check works

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68723ddd11208332bcb750a24df9f112